### PR TITLE
Update the macOS version in github actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest,macos-latest]
+        os: [ubuntu-latest,macos-11]
 
     env:
       CC: clang
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest,macos-latest]
+        os: [ubuntu-latest,macos-11]
 
     env:
       CC: gcc-10


### PR DESCRIPTION
Change the github actions macOS runtime environment version to macOS Big Sur 11
reason: macOS Big Sur 11 is the most popular version of macOS now